### PR TITLE
Fix docker automated builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@
 # Needs to be connected to a web server container to report
 
 FROM python:2.7-slim as build
-#RUN "${VERSION:?Build argument needs to be set and non-empty.}"
 ARG VERSION
 RUN ["/bin/bash", "-c", ": ${VERSION:?Expected docker build --build-arg version=xxx ... }"]
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,22 @@
+#
+# (c) Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# docker automated builds sets a number of env vars including
+#  CACHE_TAG: the Docker repository tag being built.
+#  DOCKER_REPO: the name of the Docker repository being built.
+# https://docs.docker.com/docker-cloud/builds/advanced/#environment-variables-for-building-and-testing
+
+docker build --build-arg VERSION="$CACHE_TAG" -t "$DOCKER_REPO:$CACHE_TAG" -t "$DOCKER_REPO:latest" .


### PR DESCRIPTION
Add a custom build hook for docker automated builds to inject the github
tag/release into the built image.