### PR TITLE
Improvements to docker automated build

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -28,4 +28,4 @@ else
     VERSION="$SOURCE_BRANCH-${GIT_SHA1::8}"
 fi
 
-docker image build --build-arg VERSION="$SOURCE_BRANCH" -t "$DOCKER_REPO:$VERSION" -t "$DOCKER_REPO:latest" .
+docker image build --build-arg VERSION="$SOURCE_BRANCH" --tag "$DOCKER_REPO:$VERSION"

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# (c) Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+docker tag $IMAGE_NAME $DOCKER_REPO:latest
+docker push $DOCKER_REPO:latest


### PR DESCRIPTION
Cannot seem to tag and push more than one image in the docker automated
build hook.

https://github.com/docker/hub-feedback/issues/341#issuecomment-248722131
suggests pushing a second image (latest in our case) from the post_push
hook as a workaround.