### PR TITLE
Pre-release version changes

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -25,7 +25,8 @@
 if [[ $SOURCE_BRANCH =~ ^[0-9].[0-9].[0-9]$ ]]; then
     VERSION="$SOURCE_BRANCH"
 else
-    VERSION="$SOURCE_BRANCH-${GIT_SHA1::8}"
+    git fetch --unshallow origin
+    VERSION=$(git describe --tags)
 fi
 
 docker image build --build-arg VERSION="$VERSION" --tag "$DOCKER_REPO:$VERSION" .


### PR DESCRIPTION
Use git describe output in pre-release versions (assuming these commands
will run in the public docker automated build environment).