### PR TITLE
Removed hard-coded master branch in crontab

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,16 @@ export VERSION=$(git describe --tags); docker build --build-arg VERSION=$VERSION
 (assumes projects.json is in your pwd, adjust the -v as neccesary if not)
 
 ```
-docker run -v $(pwd)/projects.json:/projects.json -e GERRIT_URL=<gerrit url> -e GITHUB_URL=<github enterprise url> -e GITHUB_TOKEN=<github token> zingstats/zing-stats:<version>
+docker run -v $(pwd)/projects.json:/projects.json -e GERRIT_URL=<gerrit url> -e GITHUB_URL=<github enterprise url> -e GITHUB_TOKEN=<github token> [-e BRANCHES="<branch name> <branch name> <branch name>"] zingstats/zing-stats:<version>
 ```
 
 e.g.
 
 ```
-docker run -v $(pwd)/projects.json:/projects.json -e gerrit_host=https://review.openstack.org/ -e github_host=https://github.com/ zingstats/zing-stats:latest
+docker run -v $(pwd)/projects.json:/projects.json -e GERRIT_URL=https://review.openstack.org/ -e GITHUB_URL=https://github.com/ -e BRANCHES="master devel" zingstats/zing-stats:latest
 ```
+
+BRANCHES is optional, if unspecified, zing-stats will analyse changes to all branches.
 
 ### Running in docker compose
 

--- a/crontab
+++ b/crontab
@@ -4,6 +4,6 @@
 # create index file daily
 0   7   *   *   *     echo '<a href="last_7d/">Zing stats for last 7 days</a><br><a href="last_30d/">Zing stats for last 30 days</a>' > /var/www/html/index.html
 # generate 7 day stats every 15 min
-*/15 *   *   *   *     /usr/local/bin/zing_stats -b master -l /dev/stderr -o /var/www/html --projects /projects.json
+*/15 *   *   *   *     /usr/local/bin/zing_stats -l /dev/stderr -o /var/www/html --projects /projects.json
 # generate 30 day stats every hour
-0   */1 *   *   *     /usr/local/bin/zing_stats -r 720 -b master -l /dev/stderr -o /var/www/html --projects /projects.json
+0   */1 *   *   *     /usr/local/bin/zing_stats -r 720 -l /dev/stderr -o /var/www/html --projects /projects.json


### PR DESCRIPTION
zing-stats container will now default to running against all branches.
Users can over-ride this behaviour by passing the BRANCHES environment
variable to docker run.