### PR TITLE
Add back in json output

### DIFF
--- a/zingstats/__init__.py
+++ b/zingstats/__init__.py
@@ -15,4 +15,3 @@
 #
 
 __all__ = ['changes', 'parser', 'util']
-

--- a/zingstats/__init__.py
+++ b/zingstats/__init__.py
@@ -15,3 +15,4 @@
 #
 
 __all__ = ['changes', 'parser', 'util']
+

--- a/zingstats/zing_stats.py
+++ b/zingstats/zing_stats.py
@@ -43,6 +43,7 @@ from datetime import timedelta
 
 import jinja2
 import pandas as pd
+import pkg_resources
 import plotly
 import requests
 from plotly import graph_objs as go
@@ -87,6 +88,10 @@ def main():
     parser.set_defaults(
         script_dir=os.path.abspath((os.path.dirname(script_name)))
     )
+
+    parser.add_argument('--version', action='version',
+                        version='%(prog)s ' + pkg_resources.get_distribution(
+                            'zingstats').version)
     parser.add_argument('-b', '--branch', dest='branches',
                         default=os.getenv('BRANCHES', '').split(),
                         action='append',
@@ -965,7 +970,7 @@ def generate_html(args, df, num_changes, start_dt, finish_dt,
         status_plot=plot_ci_success_failure(df_plot, group),
         projects_map=projects_map,
         not_found_proj=not_found_proj,
-        zs_ver=os.getenv('TAG', ''))
+        zs_ver=pkg_resources.get_distribution('zingstats').version)
     return html
 
 

--- a/zingstats/zing_stats.py
+++ b/zingstats/zing_stats.py
@@ -1126,34 +1126,5 @@ def plot_changes(df_plot, group):
     return changes_plot
 
 
-def generate_json(df_changes_by_project):
-    """
-    Returns pretty printed json of combined dataframes for all projects
-    """
-    frames = list()
-    for project in sorted(df_changes_by_project):
-        df = df_changes_by_project[project]
-        frames.append(df)
-    df = pd.concat(frames)
-    df = df.resample('1H').apply(({
-        'created': 'sum',
-        'merged': 'sum',
-        'updated': 'sum',
-        'ci_total_time_sec': 'sum',
-        'ci_longest_time_sec': 'max',
-        'ci_success': 'sum',
-        'ci_failure': 'sum',
-        'lifespan_sec': 'max',
-        'recheck': 'sum',
-        'reverify': 'sum',
-        'revisions': 'mean',
-    })).fillna(0)
-    df_as_json = json.loads(df.to_json(orient='index', date_format='iso'))
-    return(json.dumps(df_as_json,
-                      sort_keys=True,
-                      indent=4,
-                      separators=(',', ': ')))
-
-
 if __name__ == "__main__":
     main()

--- a/zingstats/zing_stats.py
+++ b/zingstats/zing_stats.py
@@ -1029,7 +1029,7 @@ def plot_ci_job_time(args, df_plot, group):
             'width': 2,
             'dash': 'dot'}}
     ci_job_recommended_max_label = go.Scatter(
-        x=[df_plot.index.min() + 1],
+        x=[df_plot.index.min() + timedelta(days=1)],
         y=[args.ci_job_recommended_max_minutes +
            (args.ci_job_recommended_max_minutes * 0.05)],
         mode='text',
@@ -1073,7 +1073,7 @@ def plot_ci_capacity(args, df_plot, group):
             'width': 2,
             'dash': 'dot'}}
     ci_75pct_capacity_line_label = go.Scatter(
-        x=[df_plot.index.min() + 1],
+        x=[df_plot.index.min() + timedelta(days=1)],
         y=[system_capacity_max_ci_minutes +
            (system_capacity_max_ci_minutes * 0.05)],
         mode='text',

--- a/zingstats/zing_stats.py
+++ b/zingstats/zing_stats.py
@@ -314,7 +314,6 @@ def write_html(args, df, num_changes, start_dt, finish_dt, projects,
         file_prefix = 'last_%dh' % args.range_hours
     else:
         file_prefix = 'last_%gd' % round((args.range_hours / 24), 1)
-    all_projects = teams_map['All']
     for team in sorted(teams_map):
         team_projects = teams_map[team]
         teams = sorted(teams_map.keys())

--- a/zingstats/zing_stats.py
+++ b/zingstats/zing_stats.py
@@ -279,9 +279,12 @@ def project_dataframe(df, df_change_stats, df_ci_stats, project):
             project)
         exit(1)
     df[project] = pd.concat([df_change_stats, df_ci_stats], sort=True)
-    df[project].index = pd.to_datetime(df[project].index)
+    df[project].index = pd.to_datetime(df[project].index, utc=True)
     df[project].sort_index(inplace=True)
     df[project].fillna(value=0, inplace=True)
+    if df[project].index.tz is None:
+        df[project] = df[project].tz_localize('UTC', ambiguous='infer')
+    df[project] = df[project].tz_convert(None)
     log.debug('df[%s]:\n%s', project, df[project])
 
 


### PR DESCRIPTION
* Add in json output variant (--format json, default is still html)
* Fixed timezone handling issues that arose from moving to latest Pandas (0.24.2)
* Refactored write_html() to reduce code duplication in generating json output.
* Explicitly specifiy units (1 day) when adding to index.min() 
* Start reporting out the package version in both html and the cli